### PR TITLE
WIP: try concurrent.futures/multiprocessing, instead of snakemake ;)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 name = "sourmash_plugin_sketchall"
 requires-python = ">=3.8"
 version = "0.1"
-requires
 
 [build-system]
 requires = ["snakemake", "sourmash>=4.6.1"]

--- a/src/sourmash_plugin_sketchall.py
+++ b/src/sourmash_plugin_sketchall.py
@@ -7,11 +7,16 @@ IDEAS:
 - support ignoring or limiting to a particular extension
 """
 import os
-import subprocess
 import sys
+from concurrent.futures import ProcessPoolExecutor
+
+import screed
 import sourmash
 from sourmash import plugins
-from sourmash.logging import debug_literal
+from sourmash.logging import debug_literal, notify
+from sourmash.command_sketch import _signatures_for_sketch_factory
+from sourmash.command_compute import add_seq
+from sourmash import sourmash_args
 
 
 class Command_SketchAll(plugins.CommandLinePlugin):
@@ -23,55 +28,57 @@ class Command_SketchAll(plugins.CommandLinePlugin):
         p.add_argument('location')
         p.add_argument('-j', '-c', '--cores', type=int, default=4,
                        help="number of processes/cores to use")
-        p.add_argument('-n', '--dry-run', '--dryrun', action='store_true',
-                       help="only print out what would be run, do not execute")
 
     def main(self, args):
         super().main(args)
         debug_literal(f"sketchall main: location is {args.location}")
-        print(sys.executable)
 
         debug = 1 if args.debug else 0
 
-        run_snakemake(config_params=[f"location={args.location}",
-                                     f"debug={debug}"],
-                      cores=args.cores, dry_run=args.dry_run)
+        # build params obj
+        sig_factory = _signatures_for_sketch_factory([], 'dna')
+
+        # find all files that don't end in .sig.gz or .sig, run on 'em
+        FILES = []
+        for root, dirs, files in os.walk(args.location, topdown=False):
+            for name in files:
+                if not name.endswith('.sig') and not name.endswith('.sig.gz'):
+                    filename = os.path.join(root, name)
+                    #FILES.append(filename + '.sig.gz')
+                    FILES.append(filename)
+
+        debug_literal(f"found {len(FILES)} files.")
+
+        with ProcessPoolExecutor(max_workers=args.cores) as executor:
+            for filename in FILES:
+                executor.submit(compute_sig, sig_factory, filename)
 
 
-def get_snakefile_path(name):
-    thisdir = os.path.dirname(__file__)
-    snakefile = os.path.join(thisdir, name)
-    return snakefile
+def compute_sig(factory, filename):
+    sigfile = filename + '.sig.gz'
 
+    with screed.open(filename) as screed_iter:
+        if not screed_iter:
+            notify(f"no sequences found in '{filename}'?!")
+            return
 
-def run_snakemake(*,
-                  snakefile_name="sketchall.snakefile",
-                  config_params=[],
-                  extra_args=[],
-                  subprocess_args=None,
-                  cores=1,
-                  dry_run=False,
-):
-    # find the Snakefile relative to package path
-    snakefile = get_snakefile_path(snakefile_name)
+        sigs = factory()
 
-    # basic command
-    cmd = [sys.executable, "-m", "snakemake", "-s", snakefile]
+        for n, record in enumerate(screed_iter):
+            if n % 10000 == 0:
+                if n:
+                    notify('\r...{} {}', filename, n, end='')
 
-    cmd += ["-j", str(cores), '-k']
+            try:
+                add_seq(sigs, record.sequence, False, False)
+            except ValueError as exc:
+                error(f"ERROR when reading from '{filename}' - ")
+                error(str(exc))
+                return
 
-    # add rest of snakemake arguments
-    cmd += list(extra_args)
+            notify('...{} {} sequences', filename, n, end='')
+        notify(f'calculated {len(sigs)} signatures for {n+1} sequences in {filename}')
 
-    # add config params
-    config_params = list(config_params)
-
-    if config_params:
-        cmd += ["--config", *config_params]
-
-    debug_literal(f"sketchall: snakemake command is {repr(cmd)}")
-
-    # runme
-    if subprocess_args is None:
-        subprocess_args = {}
-    return subprocess.run(cmd, **subprocess_args)
+        with sourmash_args.SaveSignaturesToLocation(sigfile) as save_sig:
+            for ss in sigs:
+                save_sig.add(ss)

--- a/src/sourmash_plugin_sketchall.py
+++ b/src/sourmash_plugin_sketchall.py
@@ -32,6 +32,7 @@ class Command_SketchAll(plugins.CommandLinePlugin):
                        choices={ "sig", "sig.gz", "zip", "sqldb" })
         p.add_argument('-p', '--param-string', default=['dna'],
                        help='signature parameters to use.', action='append')
+        p.add_argument('-o', '--outdir', '--output-directory')
 
     def main(self, args):
         super().main(args)
@@ -68,14 +69,18 @@ class Command_SketchAll(plugins.CommandLinePlugin):
             with ProcessPoolExecutor(max_workers=args.cores) as executor:
                 for filename in FILES:
                     executor.submit(compute_sig, factories, filename,
-                                    extension=args.extension)
+                                    extension=args.extension,
+                                    outdir=args.outdir)
         else:
             notify(f"NOTE: running in serial mode, not parallel, because cores={args.cores}")
             for filename in FILES:
                 compute_sig(factories, filename, extension=args.extension)
 
 
-def compute_sig(factories, filename, *, extension='sig.gz'):
+def compute_sig(factories, filename, *, extension='sig.gz', outdir=None):
+    "Build one set of sketches for the given filename."
+    assert outdir is None
+
     sigfile = filename + '.' + extension
 
     with screed.open(filename) as screed_iter:


### PR DESCRIPTION
This PR switches to using `concurrent.futures` [link](https://docs.python.org/3/library/concurrent.futures.html#concurrent.futures.ProcessPoolExecutor) rather than snakemake, as in the main branch.

results on 64 genomes (podar-ref):

one thread:  6.40s user 0.62s system 93% cpu 7.512 total
four threads:  9.04s user 1.41s system 279% cpu 3.743 total

NOTE: the sourmash CLI plugins code is in PR https://github.com/sourmash-bio/sourmash/pull/2438, not yet in main branch on sourmash.