### PR TITLE
EXP: try multithreading rather than multiprocessing

### DIFF
--- a/src/sourmash_plugin_sketchall.py
+++ b/src/sourmash_plugin_sketchall.py
@@ -8,7 +8,7 @@ IDEAS:
 """
 import os
 import sys
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 import screed
 import sourmash
@@ -66,7 +66,7 @@ class Command_SketchAll(plugins.CommandLinePlugin):
 
         # run things in parallel:
         if args.cores > 1:
-            with ProcessPoolExecutor(max_workers=args.cores) as executor:
+            with ThreadPoolExecutor(max_workers=args.cores) as executor:
                 for filename in FILES:
                     executor.submit(compute_sig, factories, filename,
                                     extension=args.extension,


### PR DESCRIPTION
If I'm reading the below numbers right, it seems like using multiple threads is more efficient (less system overhead) and that more than makes up for the reduced CPU usage?

## with multithreading (this PR)
```
sourmash scripts sketchall podar-all -j 8  7.13s user 0.60s system 301% cpu 2.563 total
```

## with multiprocessing (parent branch)
```
sourmash scripts sketchall podar-all -j 8  13.42s user 1.62s system 530% cpu 2.834 total
```

